### PR TITLE
Change search to check the run_list

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,5 @@ maintainer_email "noah@coderanger.net"
 license          "Apache 2.0"
 description      "Install and configure the collectd monitoring daemon"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.0"
+version          "1.0.1"
 supports         "ubuntu"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -20,7 +20,7 @@
 include_recipe "collectd"
 
 servers = []
-search(:node, "recipes:collectd\\:\\:server AND chef_environment:#{node.chef_environment}") do |n|
+search(:node, "run_list:itison-base\\:\\:monitoring_server AND chef_environment:#{node.chef_environment}") do |n|
   servers << n['fqdn']
 end
 


### PR DESCRIPTION
This makes the cookbook specific to our (Itison's) system, but it should avoid the issue where clients cannot find the server if chef is running on the server at the same time, which causes repeated problems for us.
